### PR TITLE
Update repository field in package.json

### DIFF
--- a/packages/earljs/package.json
+++ b/packages/earljs/package.json
@@ -18,7 +18,7 @@
     "expect",
     "exception"
   ],
-  "repository": "git@github.com:earl-js/earl.git",
+  "repository": "dethcrypto/earl",
   "author": "Kris Kaczor <chris@kaczor.io>",
   "license": "MIT",
   "version": "0.2.3",


### PR DESCRIPTION
Changed to reflect current org name, and used the shorthand syntax (GitHub is the default)

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository