### PR TITLE
Update async-functions.md

### DIFF
--- a/packages/docs/guides/async-functions.md
+++ b/packages/docs/guides/async-functions.md
@@ -13,7 +13,7 @@ resolve. Instead, we encourage you to use `async/await` syntax:
 ```typescript
 function delay(n: number): Promise<void> {
   return new Promise((resolve) => {
-    setInterval(resolve, n)
+    setTimeout(resolve, n)
   })
 }
 


### PR DESCRIPTION
There was a bug in the async example, which lead to `mocha` never exiting.